### PR TITLE
Move ig down

### DIFF
--- a/_includes/instagram_cards.html
+++ b/_includes/instagram_cards.html
@@ -41,7 +41,6 @@ $(document).ready(function(){
     instagramImage.url = item.images.standard_resolution.url;
     var date = new Date(parseInt(item.created_time) * 1000);
     instagramImage.formattedDate = formatDate(date);
-    debugger;
     return instagramImage;
   }
 

--- a/index.html
+++ b/index.html
@@ -6,14 +6,6 @@ layout: default
 
 <div class="container">
   <div class="row">
-    <div class="col-md-12">
-      {% include images.html %}
-    </div>
-  </div>
-
-  <div style="margin:50px;"></div>
-
-  <div class="row">
     <div class="col-md-6">
       {% include events.html %}
     </div>
@@ -22,4 +14,11 @@ layout: default
       {% include twitter_widget.html %}
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      {% include images.html %}
+    </div>
+  </div>
+
 </div>


### PR DESCRIPTION
On mobile, it's hard to see the upcoming events when instagram takes up so much vertical space. Two people I've sent the site to recently have followed up asking "what time is it and where" - and lol that's 100% why I sent them the link xD

Instagram should be below events; that's this PR~